### PR TITLE
Fix CSS build: inline @import partials instead of copying _css dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,17 @@ mkdir assets
 mkdir assets/css
 
 ## CSS
-cp _assets/main.css assets/css/main.css
-cp -r _assets/_css assets/css/
+# Inline @import statements into a single file; Jekyll excludes _* directories
+# so the _css partials would otherwise be missing from the built site.
+{
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^@import\ \'_css/(.+)\'\; ]]; then
+      cat "_assets/_css/${BASH_REMATCH[1]}"
+    else
+      echo "$line"
+    fi
+  done < _assets/main.css
+} > assets/css/main.css
 
 ## Images
 cp -r _assets/_images assets/img/


### PR DESCRIPTION
Jekyll excludes directories with a leading underscore from its build
output, so `assets/css/_css/` was never included in the built site.
This meant all the `@import '_css/...'` statements in main.css
resolved to 404s, leaving the site with no styles.

Fix by replacing the separate copy approach with a shell loop that
reads main.css and inlines each @import'd partial in place, producing
a single concatenated main.css with no external imports needed.

https://claude.ai/code/session_01W8e6aCjXhgSqpEvAHcGeLB